### PR TITLE
Add skeleton design document for rows and subtyping

### DIFF
--- a/designs/rows-and-subtyping.md
+++ b/designs/rows-and-subtyping.md
@@ -1,0 +1,35 @@
+# Rows and Subtyping
+
+This sub-track of the high-road type-checker design deals with row
+polymorphism and subtyping. In particular, that means:
+
+  - Object types
+  - Polymorphic variant types
+  - Algebraic effects
+
+## Outline
+
+### Members
+
+  - Leo White
+  - Didier Remy
+  - Francois Pottier
+  - Jacques Garrigue
+
+### Open questions
+
+  - What form(s) of row polymorphism should we use?
+
+  - Can we use a single underlying implementation for all three language features?
+
+  - Can/should subtyping be made implicit?
+
+  - How best to represent rows within Inferno?
+
+### Schedule of work
+
+  TODO
+
+### Bibliography
+
+  TODO


### PR DESCRIPTION
I've written a skeleton design document just listing the members and some open questions about the design.

I'd also like to put in some kind of schedule/plan about who/when some things might happen around this track, but I've left it blank for now so we can discuss it in the comments.

Similarly, I've left a blank bibliography for us to fill in with relevant papers etc.