### PR TITLE
OCaml Language Committee: conflicts of interest

### DIFF
--- a/Committee.md
+++ b/Committee.md
@@ -140,9 +140,8 @@ There is no process for members of the public at large to directly add or remove
 ## Conflicts of interest
 
 The committee hopes to reflect the various interests of the OCaml community from
-academia to the various industrial users. Conflicts of interests might introduce
-(often unconscious) biases that might cloud the technical discussion or reduce
-the diversity of point of views.
+academia to the various industrial users. Conflicts of interest might introduce
+biases that cloud technical judgement.
 
 Thus we expect committee member to disclose such conflicts. Currently, the
 committee classifies at least the following situations as being unconditional


### PR DESCRIPTION
This PR proposes to amend the description of the OCaml Language Committee to add a transparency-based policy for handling conflicts of interest.

The main idea is that with the level of interconnection of the OCaml community, excluding people from the committee deliberation due to conflict of interests would be counter-productive.

However, it still seems important to the member of the committee to report such conflicts to make the committee deliberation as transparent as possible for the rest of the world.

As a small supplementary step, we also propose that the summary of the committee deliberation should be delegated to a non-conflicting member of the committee in the case where the shepherd is conflicted.

Moreover, since the clearest source of conflicts stems from shared affiliations, this PR adds an affiliation field to the list of committee member.